### PR TITLE
Adiciona campo para enviar qualidade do sinal (RSSI)

### DIFF
--- a/telemetry/telemetry.proto
+++ b/telemetry/telemetry.proto
@@ -75,6 +75,7 @@ enum Resource {
     RESOURCE_PH = 65;
     RESOURCE_MESH_LEVEL = 66;
     RESOURCE_PRECIPITATION = 67;          // mm
+    RESOURCE_SIGNAL_STRENGTH = 68;        // dBm
 }
 
 enum NetworkType {


### PR DESCRIPTION
### Mudanças:

adicionado recurso de telemetria:
`RESOURCE_SIGNAL_STRENGTH = 68;        // dBm`
para envio de qualidade de sinal de rede.